### PR TITLE
♻️ [REFACT] MBTI 결과 로직 변경

### DIFF
--- a/src/main/java/com/smartbrush/smartbrush_backend/service/ScalpMbtiServiceImpl.java
+++ b/src/main/java/com/smartbrush/smartbrush_backend/service/ScalpMbtiServiceImpl.java
@@ -6,22 +6,72 @@ import org.springframework.stereotype.Service;
 public class ScalpMbtiServiceImpl {
 
     public String getMbti(int sensitivity, int sebum, int scaling, int density, int thickness) {
-        if (sensitivity >= 70 && sebum >= 70) {
-            return "지성 민감형";
-        } else if (sensitivity >= 70 && sebum <= 40) {
-            return "민감 건조형";
-        } else if (scaling >= 70 && sebum >= 70) {
-            return "지성 비듬형";
-        } else if (scaling >= 70 && sebum <= 40) {
-            return "건조 비듬형";
-        } else if (sensitivity >= 60 && scaling >= 60 && sebum <= 45) {
-            return "건조 트러블형";
-        } else if (sensitivity >= 60 && scaling >= 60 && sebum >= 65) {
+
+        boolean lowDensity    = density   <= 45;
+        boolean lowThickness  = thickness <= 45;
+        boolean weakStructure = lowDensity || lowThickness;
+        boolean strongStructure = density >= 65 && thickness >= 65;
+
+        // 1) 트러블 폭풍형
+        if ((sensitivity >= 60 && scaling >= 60 && sebum >= 65 && weakStructure)
+                || (sensitivity >= 60 && scaling >= 60 && sebum >= 70)
+                || (sensitivity >= 70 && scaling >= 70 && sebum >= 60)) {
             return "트러블 폭풍형";
-        } else if (sebum >= 65 && sensitivity <= 45 && scaling <= 45) {
+        }
+
+        // 2) 지성 민감형
+        if ((sensitivity >= 70 && sebum >= 70)
+                || (sensitivity >= 65 && sebum >= 65 && weakStructure)) {
+            return "지성 민감형";
+        }
+
+        // 3) 민감 건조형
+        if ((sensitivity >= 70 && sebum <= 40)
+                || (sensitivity >= 65 && sebum <= 45 && weakStructure)) {
+            return "민감 건조형";
+        }
+
+        // 4) 지성 비듬형
+        if ((scaling >= 70 && sebum >= 70)
+                || (scaling >= 65 && sebum >= 65 && weakStructure)) {
+            return "지성 비듬형";
+        }
+
+        // 5) 건조 비듬형
+        if ((scaling >= 70 && sebum <= 40)
+                || (scaling >= 65 && sebum <= 45 && weakStructure)) {
+            return "건조 비듬형";
+        }
+
+        // 6) 건조 트러블형
+        if ((sensitivity >= 60 && scaling >= 60 && sebum <= 45)
+                || (sensitivity >= 55 && scaling >= 55 && sebum <= 50 && weakStructure)) {
+            return "건조 트러블형";
+        }
+
+        // 7) 깔끔 지성형
+        if (sebum >= 65 && sensitivity <= 45 && scaling <= 45 && strongStructure) {
             return "깔끔 지성형";
-        } else {
+        }
+        // 구조가 약해도 유분이 높고 나머지가 낮으면 fallback으로 인정
+        if (sebum >= 70 && sensitivity <= 40 && scaling <= 40) {
+            return "깔끔 지성형";
+        }
+
+        // 8) 약한 구조로 인한 보정
+        if (weakStructure && sensitivity >= 55 && scaling >= 55) {
+            return (sebum <= 55) ? "건조 트러블형" : "트러블 폭풍형";
+        }
+
+        // 9) 밸런스형
+        boolean midSensitivity = sensitivity >= 40 && sensitivity <= 60;
+        boolean midSebum       = sebum       >= 40 && sebum       <= 60;
+        boolean midScaling     = scaling     >= 40 && scaling     <= 60;
+        if (midSensitivity && midSebum && midScaling && strongStructure) {
             return "밸런스형";
         }
+
+        // 10) 그 외 애매하면 기본값
+        return "밸런스형";
     }
 }


### PR DESCRIPTION
## ⛓️ 연관된 이슈
close #113 

## 📝 작업 내용
MBTI 로직 변경
트러블 폭풍형 → 민감도↑ + 각질↑ + 유분↑
지성 민감형 → 민감도↑ + 유분↑
민감 건조형 → 민감도↑ + 유분↓
지성 비듬형 → 각질↑ + 유분↑
건조 비듬형 → 각질↑ + 유분↓
건조 트러블형 → 민감도↑ + 각질↑ + 유분↓
깔끔 지성형 → 유분↑ + (민감도↓ & 각질↓)
밸런스형 → 민감도·유분·각질이 모두 중간 범위

- 5가지 지표를 다 쓰고, 민감·유분·각질 3개는 메인으로 밀도·굵기 2개는 보정으로 사용함
- 조건에 맞는 유형이 있으면 그걸 반환하고, 애매하면 보정해서 트러블이나 밸런스 쪽으로 정함

## 📷 스크린샷

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요-->

## 💬 리뷰 요구사항(선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
